### PR TITLE
Extend logging of proceedToAfterExecSpinlocks

### DIFF
--- a/lib/private/Deferred.js
+++ b/lib/private/Deferred.js
@@ -804,7 +804,7 @@ function proceedToAfterExecSpinlocks (errCbArg, resultCbArg, extraCbArgs, self, 
         '```\n'+
         flaverr.getBareTrace(self._omen)+'\n'+
         '```\n'+
-        'And here is errCbArg:\n'+
+        'Here is the original error:\n'+
         '```\n'+
         errCbArg+
         '```\n'+

--- a/lib/private/Deferred.js
+++ b/lib/private/Deferred.js
@@ -804,6 +804,10 @@ function proceedToAfterExecSpinlocks (errCbArg, resultCbArg, extraCbArgs, self, 
         '```\n'+
         flaverr.getBareTrace(self._omen)+'\n'+
         '```\n'+
+        'And here is errCbArg:\n'+
+        '```\n'+
+        errCbArg+
+        '```\n'+
         '\n'
       ):'')+
       ' [?] For more help, visit https://sailsjs.com/support\n'+


### PR DESCRIPTION
Ties in with https://github.com/balderdashy/sails/issues/4502 and https://github.com/balderdashy/sails/issues/4400

While @mikermcneil has valid points that we *should* be using async/await, there are times when callbacks are still used and the message/trace inside `errCbArg` would otherwise be lost.