### PR TITLE
Deferred.getInvocationInfo.proceedToAfterExecSpinlocks error logging

### DIFF
--- a/lib/private/Deferred.js
+++ b/lib/private/Deferred.js
@@ -803,13 +803,15 @@ function proceedToAfterExecSpinlocks (errCbArg, resultCbArg, extraCbArgs, self, 
         'To assist you in hunting this down, here is a stack trace:\n'+
         '```\n'+
         flaverr.getBareTrace(self._omen)+'\n'+
-        '```\n'+
+        '```\n'
+      ):'')+
+      (errCbArg?(
         'Here is the original error:\n'+
         '```\n'+
         errCbArg+
-        '```\n'+
-        '\n'
+        '```\n'
       ):'')+
+      '\n'+
       ' [?] For more help, visit https://sailsjs.com/support\n'+
       '- - - - - - - - - - - - - - - - - - - - - - - - - - - - - -'
     );


### PR DESCRIPTION
Inside a vanilla `function()` method (as opposed to async/promise etc) in a SailsJS service attempting to access the property of an undefined results in an error that has not triggered creation of an omen, so only getting logging of

```
5|WW-API | - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
5|WW-API | WARNING: Something seems to be wrong with this function.
5|WW-API | It is trying to signal that it has finished AGAIN, after
5|WW-API | already resolving/rejecting once.
5|WW-API | (silently ignoring this...)
5|WW-API |  [?] For more help, visit https://sailsjs.com/support
5|WW-API | - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
```

This PR extends how `Deferred.getInvocationInfo.proceedToAfterExecSpinlocks` handles passed params - to log out the original error even if no omen exists yet, and to also only log errCbArg if it actually exists.

@mikermcneil I should've done this originally in https://github.com/mikermcneil/parley/pull/6 :) 