### PR TITLE
Provide real error.

### DIFF
--- a/lib/private/Deferred.js
+++ b/lib/private/Deferred.js
@@ -806,7 +806,7 @@ function proceedToAfterExecSpinlocks (errCbArg, resultCbArg, extraCbArgs, self, 
         '```\n'+
         'Here is the original error:\n'+
         '```\n'+
-        errCbArg+
+        errCbArg ? errCbArg : self._omen.raw.stack +
         '```\n'+
         '\n'
       ):'')+

--- a/lib/private/Deferred.js
+++ b/lib/private/Deferred.js
@@ -806,7 +806,7 @@ function proceedToAfterExecSpinlocks (errCbArg, resultCbArg, extraCbArgs, self, 
         '```\n'+
         'Here is the original error:\n'+
         '```\n'+
-        errCbArg ? errCbArg : self._omen.raw.stack +
+        (errCbArg ? errCbArg : self._omen.raw.stack) +
         '```\n'+
         '\n'
       ):'')+


### PR DESCRIPTION
So in our case `errCbArg` is `undefined`:

![image](https://user-images.githubusercontent.com/3603448/120069760-57348d80-c0a9-11eb-80e3-b1291b4b5151.png)

But `self._omen.raw.stack` contains real error and stack:

![image](https://user-images.githubusercontent.com/3603448/120069816-ab3f7200-c0a9-11eb-9e75-0d05d5f6a296.png)

Spent a few hours on this, I hope we can save many more in future, and for other people, if you merge this @mikermcneil. Thank you! 